### PR TITLE
Fixes Typo in enum

### DIFF
--- a/help/HowTo Edit Your Own Spline 3D.vl
+++ b/help/HowTo Edit Your Own Spline 3D.vl
@@ -95,7 +95,7 @@
             <Pin Id="MKVo70nKoJaOtZnIlOSBrG" Name="Spline" Kind="InputPin" />
             <Pin Id="B6VFmwPgPVIONCfPEKDbmK" Name="Thickness" Kind="InputPin" />
             <Pin Id="MHS1gw0lXR8NN04h3mnCdg" Name="Normal Bending" Kind="InputPin" DefaultValue="False" />
-            <Pin Id="CbM9C6InVo4Ny0qBVcruxS" Name="Thickness Space" Kind="InputPin" DefaultValue="Wolrd" />
+            <Pin Id="CbM9C6InVo4Ny0qBVcruxS" Name="Thickness Space" Kind="InputPin" DefaultValue="World" />
             <Pin Id="CKxfJmSo1jZLU7ucmm1V08" Name="Mesh Type" Kind="InputPin" DefaultValue="Ribbon" />
             <Pin Id="PbmyWE9B08lMb3NbYqyxXq" Name="Tube Resolution" Kind="InputPin" />
             <Pin Id="IdsQv3ZTicdNUEU2EDmoBe" Name="Material" Kind="InputPin" />

--- a/help/HowTo Use Spline 3D.vl
+++ b/help/HowTo Use Spline 3D.vl
@@ -462,7 +462,7 @@
             <Pin Id="PCwxpxCMQblP5ruTutxtGv" Name="Spline" Kind="InputPin" />
             <Pin Id="GaxPzxjlZLYLnwKSkCyd30" Name="Thickness" Kind="InputPin" />
             <Pin Id="MHE9IcQIJ3OLsCHWr1A3Vm" Name="Normal Bending" Kind="InputPin" DefaultValue="True" />
-            <Pin Id="IMiSIXPGrPSMlh2Fj9PiAj" Name="Thickness Space" Kind="InputPin" DefaultValue="Wolrd" />
+            <Pin Id="IMiSIXPGrPSMlh2Fj9PiAj" Name="Thickness Space" Kind="InputPin" DefaultValue="World" />
             <Pin Id="M8yWPgwW1BqM8FzmEWlCsw" Name="Mesh Type" Kind="InputPin" DefaultValue="Ribbon" />
             <Pin Id="ICpLzkGxxYjOrxQIJc15ut" Name="Tube Resolution" Kind="InputPin" DefaultValue="8" />
             <Pin Id="FKbk6HrCYfjPdwPnjNOn0D" Name="Up Vector" Kind="InputPin" DefaultValue="1, 0, 0" />

--- a/src/enum.cs
+++ b/src/enum.cs
@@ -3,7 +3,7 @@
 
 public enum ThicknessSpace
 {
-    Wolrd = 0,
+    World = 0,
     Pixel
 }
 


### PR DESCRIPTION
I've found this little typo while studying the help patches. Not sure though how to make them appear in the patches... does it have to be built?